### PR TITLE
curl fall back to wget

### DIFF
--- a/dashboards.sh
+++ b/dashboards.sh
@@ -2,7 +2,7 @@
 
 # Author: Carlos Cuezva
 # Created: January 2023
-# Last updated: 03/03/2023
+# Last updated: 06/09/2023
 # Source: https://github.com/CarlosCuezva/dashboards-Grafana-Teslamate/blob/menu/dashboards.sh
 #
 # URL specifies the URL of the Grafana instance.
@@ -17,8 +17,13 @@
 
 set -o errexit
 
+GH_USER="CarlosCuezva"
+GH_REPO="dashboards-Grafana-Teslamate"
+
 main() {
   local task=$1
+
+  read_config
 
   case $task in
       autoupdate) autoupdate;;
@@ -33,7 +38,7 @@ menu() {
 
   local get_current_version=$(get_current_version)
   local get_last_release=$(get_last_release)
-  
+
   echo "
 INSTALLED VERSION: ${get_current_version}
 LAST RELEASE:      ${get_last_release}
@@ -67,18 +72,23 @@ LAST RELEASE:      ${get_last_release}
 }
 
 
-restore() {
-  local auto=$1
+read_config() {
   source ./config.sh
 
   echo "
 URL:                   $URL
 DASHBOARDS_DIRECTORY:  $DASHBOARDS_DIRECTORY
 DESTINATION_DIRECTORY: $DESTINATION_DIRECTORY
+GITHUB_SAVE_TO_FILE:   $GITHUB_SAVE_TO_FILE
+GITHUB_TO_CONSOLE:     $GITHUB_TO_CONSOLE
   "
+}
+
+restore() {
+  local auto=$1
 
   create_folder
-  
+
   find "$DASHBOARDS_DIRECTORY" -type f -name \*.json -print0 |
       while IFS= read -r -d '' dashboard_path; do
           curl \
@@ -129,7 +139,7 @@ create_folder() {
 config_file() {
   filename="config.sh"
   echo -e "\n"
-  
+
   read -p "Enter the Grafana URL (e.g. http://localhost:3000): " url
   url="${url:=http://localhost:3000}"
   read -p "Enter the relative or absolute path of the dashboards directory  (e.g. ./dashboards): " dashboards_directory
@@ -145,12 +155,22 @@ config_file() {
   else
     [ -f "$filename" ] && rm $filename
 
+	if [ -f /etc/synoinfo.conf ]; then
+      # use wget on Synology - curl fails, perhaps due to c-ares?
+      github_save_to_file="wget -nv --no-hsts -O"
+      github_to_console="wget -nv --no-hsts -O -"
+    else
+      github_save_to_file="curl -sJL -o"
+      github_to_console="curl -s"
+    fi
     cat <<EOT >> $filename
 URL="$url"
 TOKEN="$token"
 DASHBOARDS_DIRECTORY="$dashboards_directory"
 DESTINATION_DIRECTORY="Teslamate - Custom"
 DIRECTORY_UID="AySq122Vh"
+GITHUB_SAVE_TO_FILE="$github_save_to_file"
+GITHUB_TO_CONSOLE="$github_to_console"
 EOT
 
     echo -e "\nFile \"$filename\" generated correctly."
@@ -168,7 +188,9 @@ download() {
 
   echo -e "\n"
 
-  curl -sJL -o "${GH_REPO}-${GH_BRANCH}.tar.gz" "https://github.com/${GH_USER}/${GH_REPO}/archive/refs/tags/${GH_BRANCH}.tar.gz" && \
+  # curl -sJL -o "${GH_REPO}-${GH_BRANCH}.tar.gz" "https://github.com/${GH_USER}/${GH_REPO}/archive/refs/tags/${GH_BRANCH}.tar.gz" && \
+
+  $GITHUB_SAVE_TO_FILE "${GH_REPO}-${GH_BRANCH}.tar.gz" "https://github.com/${GH_USER}/${GH_REPO}/archive/refs/tags/${GH_BRANCH}.tar.gz" && \
   tar -xzf ./"${GH_REPO}-${GH_BRANCH}.tar.gz" > /dev/null && \
   rm ./"${GH_REPO}-${GH_BRANCH}.tar.gz" && \
   cp -Rf ./"${GH_REPO}-${GH_BRANCH:1}"/* ./  && \
@@ -195,13 +217,13 @@ get_current_version(){
     echo "$c"
   else
     echo "unknown"
-  fi 
+  fi
 }
 
 get_last_release() {
   local GH_USER="CarlosCuezva"
   local GH_REPO="dashboards-Grafana-Teslamate"
-  echo $(curl -s https://api.github.com/repos/$GH_USER/$GH_REPO/releases/latest \
+  echo $($GITHUB_TO_CONSOLE https://api.github.com/repos/$GH_USER/$GH_REPO/releases/latest \
   | grep "tag_name" \
   | awk '{print substr($2, 2, length($2)-3)}');
 }


### PR DESCRIPTION
The implement of curl on Synology NAS is currently breaking up this script.

This PR adds to the config which download app (curl or wget) to use based on a file that is specific to Synology.

That said, the very first version I had made was adding a "curl check" and if it failed, then it would fall back to wget. Somehow I think this solution is still better since it can handle other odd curl on NAS or other Linux distribution.

Let me know what you think.

Note: it's not possible to completely silence wget with arguments. At least not on Synology unless using a redirect aka 2>/dev/null